### PR TITLE
Proposal: non-impl iter types

### DIFF
--- a/src/discrete_range_map.rs
+++ b/src/discrete_range_map.rs
@@ -23,7 +23,7 @@ use std::iter::once;
 use std::marker::PhantomData;
 
 use btree_monstrousity::btree_map::{
-	IntoIter as BTreeMapIntoIter, SearchBoundCustom,
+	IntoIter as BTreeMapIntoIter, Iter as BTreeMapIter, SearchBoundCustom,
 };
 use btree_monstrousity::BTreeMap;
 use either::Either;
@@ -451,7 +451,7 @@ where
 	/// assert_eq!(iter.next(), Some((&ie(8, 100), &false)));
 	/// assert_eq!(iter.next(), None);
 	/// ```
-	pub fn iter(&self) -> impl DoubleEndedIterator<Item = (&K, &V)> {
+	pub fn iter(&self) -> Iter<'_, K, V> {
 		self.inner.iter()
 	}
 
@@ -1475,6 +1475,8 @@ impl<I, K, V> Iterator for IntoIter<I, K, V> {
 		self.inner.next()
 	}
 }
+
+pub type Iter<'a, K, V> = BTreeMapIter<'a, K, V>;
 
 impl<I, K, V> Default for DiscreteRangeMap<I, K, V> {
 	fn default() -> Self {


### PR DESCRIPTION
This is not a complete piece of work, but a proposal for a change.

When an `impl T` is returned, it means that value can't be reused in another type (such as a struct). This prevents composing together this logic into higher level constructs. I was curious if you would be interested in a a change that (at least partly) moves to named types for the various types. It would require a little book-keeping, but should be doable. If yes, what do you think of using type aliases for the various iterators to make it easier for library consumers to pull in the types?