### PR TITLE
Error return val

### DIFF
--- a/src/discrete_range_set.rs
+++ b/src/discrete_range_set.rs
@@ -145,7 +145,7 @@ where
 	/// See [`DiscreteRangeMap::from_iter_strict()`] for more details.
 	pub fn from_iter_strict(
 		iter: impl Iterator<Item = K>,
-	) -> Result<DiscreteRangeSet<I, K>, OverlapError> {
+	) -> Result<DiscreteRangeSet<I, K>, OverlapError<()>> {
 		let mut set = DiscreteRangeSet::new();
 		for range in iter {
 			set.insert_strict(range)?;

--- a/src/discrete_range_set.rs
+++ b/src/discrete_range_set.rs
@@ -110,14 +110,14 @@ where
 		self.inner.contains_range(range)
 	}
 	/// See [`DiscreteRangeMap::insert_strict()`] for more details.
-	pub fn insert_strict(&mut self, range: K) -> Result<(), OverlapError> {
+	pub fn insert_strict(&mut self, range: K) -> Result<(), OverlapError<()>> {
 		self.inner.insert_strict(range, ())
 	}
 	/// See [`DiscreteRangeMap::insert_merge_touching()`] for more details.
 	pub fn insert_merge_touching(
 		&mut self,
 		range: K,
-	) -> Result<K, OverlapError> {
+	) -> Result<K, OverlapError<()>> {
 		self.inner.insert_merge_touching(range, ())
 	}
 	/// See [`DiscreteRangeMap::insert_merge_overlapping()`] for more details.
@@ -135,7 +135,7 @@ where
 	/// See [`DiscreteRangeMap::from_slice_strict()`] for more details.
 	pub fn from_slice_strict<const N: usize>(
 		slice: [K; N],
-	) -> Result<DiscreteRangeSet<I, K>, OverlapError> {
+	) -> Result<DiscreteRangeSet<I, K>, OverlapError<()>> {
 		let mut set = DiscreteRangeSet::new();
 		for range in slice {
 			set.insert_strict(range)?;


### PR DESCRIPTION
In the standard library the [BTree implementations return the passed in value in an `OccupiedError`](https://doc.rust-lang.org/std/collections/btree_map/struct.OccupiedError.html) so the consumer can reuse the value without cloning. 

Any thoughts on bringing this API in line with that? 
Possibly renaming the Error type as well? (to bring it in line, but no strong opinions here)

There is a small change from my other proposal in here as well, I'd remove it from the PR before merging.

I also ran into errors running test on the package, and made some changes so that run without issue.

Happy to talk about this or my other proposal!